### PR TITLE
docs: add JSDoc for types exported from `index.ts` - `DeepPartial` and `FileExtension`

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@drob/configate",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "MIT",
   "exports": "./src/index.ts",
   "publish": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "configate",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "configate",
-			"version": "0.1.4",
+			"version": "0.1.5",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@biomejs/biome": "1.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "configate",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"type": "module",
 	"description": "Configuration helper for TypeScript applications",
 	"main": "dist/index.js",

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,14 +1,30 @@
 // biome-ignore lint/suspicious/noExplicitAny: config can have any value
 export type DefaultConfig = Record<string, any>;
 
+/**
+ * Environment type represents all allowed application environments
+ * string is also allowed to support custom environments
+ */
 export type Environment =
     | 'development'
     | 'staging'
     | 'production'
     | 'test'
     | string;
+
+/**
+ * FileExtension type represents all allowed file extensions of config files
+ */
 export type FileExtension = 'ts' | 'mts' | 'js' | 'mjs' | 'cjs' | 'json';
 
+/**
+ * DeepPartial allows to make all properties of an object optional recursively
+ *
+ * @example
+ * ```ts
+ * type PartialConfig = DeepPartial<YourConfigStructure>
+ * ```
+ */
 export type DeepPartial<T> = T extends object
     ? {
           [P in keyof T]?: DeepPartial<T[P]>;


### PR DESCRIPTION
To reach higher score in JSR registry