### PR TITLE
fix: stop throwing error when accessing Array methods or spreading on config property

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@drob/configate",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "MIT",
   "exports": "./src/index.ts",
   "publish": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "configate",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "configate",
-			"version": "0.1.5",
+			"version": "0.1.6",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@biomejs/biome": "1.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "configate",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"type": "module",
 	"description": "Configuration helper for TypeScript applications",
 	"main": "dist/index.js",

--- a/src/makeSecureDeepProxy.test.ts
+++ b/src/makeSecureDeepProxy.test.ts
@@ -80,6 +80,18 @@ describe('makeSecureDeepProxy', () => {
         assert.throws(() => {
             proxy.a[3];
         }, /Property 3 is not defined in the config/);
+
+        assert.doesNotThrow(() => {
+            [...proxy.a];
+            Array.from(proxy.a);
+
+            proxy.a.map((x) => x * 2);
+
+            for (const _item of proxy.a) {
+            }
+
+            new Set(proxy.a);
+        }, 'Accessing array methods, spreading or using loop should not throw an error');
     });
 
     it('deeply proxies nested arrays', () => {

--- a/src/makeSecureDeepProxy.ts
+++ b/src/makeSecureDeepProxy.ts
@@ -26,9 +26,10 @@ export function makeSecureDeepProxy<T extends DefaultConfig>(config: T): T {
 function makeSecureProxy<T extends DefaultConfig>(targetObject: T): T {
     return new Proxy(targetObject, {
         get(target, prop) {
-            // Handle Symbol.toStringTag and Array properties
+            // Handle Symbol and Array properties
             if (
-                prop === Symbol.toStringTag ||
+                typeof prop === 'symbol' ||
+                // Don't throw error when using array methods
                 (Array.isArray(target) && Number.isNaN(Number(prop)))
             ) {
                 return Reflect.get(target, prop);


### PR DESCRIPTION
# Why

To fix error 
```ts
TypeError: Cannot convert a Symbol value to a number
```

# What

fix: stop throwing error when accessing Array methods or spreading on config property