### PR TITLE
feat: add support for optinal `variant` configuration

### DIFF
--- a/src/importConfigFiles.test.ts
+++ b/src/importConfigFiles.test.ts
@@ -27,6 +27,49 @@ describe('importConfigFiles', () => {
 
         process.env.SHALLOW_PROPERTY = undefined;
     });
+
+    it('loads variant-specific overrides on top of defaults', async () => {
+        const config = await importConfigFiles<TestConfig>({
+            configDir: `${import.meta.dirname}/testConfigDirs/variant`,
+            variant: 'customerA',
+            fileExtensions: ['ts'],
+        });
+
+        assert.equal(config.shallowProperty, 'default');
+        assert.equal(
+            config.nestedObject.nestedProperty1,
+            'default-customerA-n1',
+        );
+        assert.equal(config.nestedObject.nestedProperty2, 'local-customerA-n2');
+
+        const configB = await importConfigFiles<TestConfig>({
+            configDir: `${import.meta.dirname}/testConfigDirs/variant`,
+            variant: 'customerB',
+            fileExtensions: ['ts'],
+        });
+
+        assert.equal(configB.shallowProperty, 'default');
+        assert.equal(
+            configB.nestedObject.nestedProperty1,
+            'default-customerB-n1',
+        );
+    });
+
+    it('prioritizes environment+variant specific files and locals', async () => {
+        const config = await importConfigFiles<TestConfig>({
+            configDir: `${import.meta.dirname}/testConfigDirs/variant`,
+            environment: 'production',
+            variant: 'customerA',
+            fileExtensions: ['ts'],
+        });
+
+        assert.equal(config.shallowProperty, 'local-production');
+        assert.equal(
+            config.nestedObject.nestedProperty1,
+            'default-customerA-n1',
+        );
+        assert.equal(config.nestedObject.nestedProperty2, 'local-customerA-n2');
+    });
 });
 
 export type TestConfig = {

--- a/src/loadConfig.ts
+++ b/src/loadConfig.ts
@@ -10,10 +10,14 @@ import { makeSecureDeepProxy } from './makeSecureDeepProxy.ts';
  * Features:
  * - Load config files in order:
  *     1. default.ext
- *     2. {environment}.ext
- *     4. local.ext
- *     3. local-{environment}.ext
- *     5. custom-environment-variables.ext (only for .ts and .js files)
+ *     2. default-{variant}.ext
+ *     3. {environment}.ext
+ *     4. {environment}-{variant}.ext
+ *     5. local.ext
+ *     6. local-{variant}.ext
+ *     7. local-{environment}.ext
+ *     8. local-{environment}-{variant}.ext
+ *     9. custom-environment-variables.ext (only for .ts and .js files)
  * - Throw an error if a property is accessed that is not defined in the config
  * - Freeze the config object to prevent modifications
  * - Supported config file formats: TypeScript (.ts, .mts), JavaScript (.js, .mjs), JSON (.json)
@@ -22,6 +26,7 @@ import { makeSecureDeepProxy } from './makeSecureDeepProxy.ts';
  *
  * @param configDirs - paths to directories where the config files are located. Relative or absolute. Directories are merged in the array order. Default: ['${current-working-directory}/config']
  * @param environment - the environment to load the config for. Default: process.env.NODE_ENV
+ * @param variant - allows to define 2nd dimension of configs above environment. Default: undefined
  * @param fileExtensions - an array of file extensions to use when looking for config files. Configs are loaded in this order. Default: ['ts', 'js']
  * @param throwOnUndefinedProp - throw an error if a property is accessed that is not defined in the config. Default: true
  * @param freezeConfig - freeze the config object to prevent modifications. Default: true
@@ -33,6 +38,7 @@ import { makeSecureDeepProxy } from './makeSecureDeepProxy.ts';
 export async function loadConfig<Config extends DefaultConfig>({
     configDirs = [`${process.cwd()}/config`],
     environment = process.env.NODE_ENV,
+    variant,
     fileExtensions = ['ts', 'js'],
     throwOnUndefinedProp = true,
     freezeConfig = true,
@@ -46,6 +52,7 @@ export async function loadConfig<Config extends DefaultConfig>({
         const config = await importConfigFiles<Config>({
             configDir,
             environment,
+            variant,
             fileExtensions,
         });
 
@@ -71,6 +78,7 @@ export async function loadConfig<Config extends DefaultConfig>({
 type LoadConfigOptions = {
     configDirs?: string[];
     environment?: Environment;
+    variant?: string;
     fileExtensions?: FileExtension[];
     throwOnUndefinedProp?: boolean;
     freezeConfig?: boolean;

--- a/src/testConfigDirs/variant/default-customerA.ts
+++ b/src/testConfigDirs/variant/default-customerA.ts
@@ -1,0 +1,8 @@
+import type { DeepPartial } from '../../common.ts';
+import type { TestConfig } from '../../importConfigFiles.test.js';
+
+export const config: DeepPartial<TestConfig> = {
+    nestedObject: {
+        nestedProperty1: 'default-customerA-n1',
+    },
+};

--- a/src/testConfigDirs/variant/default-customerB.ts
+++ b/src/testConfigDirs/variant/default-customerB.ts
@@ -1,0 +1,8 @@
+import type { DeepPartial } from '../../common.ts';
+import type { TestConfig } from '../../importConfigFiles.test.js';
+
+export const config: DeepPartial<TestConfig> = {
+    nestedObject: {
+        nestedProperty1: 'default-customerB-n1',
+    },
+};

--- a/src/testConfigDirs/variant/default.ts
+++ b/src/testConfigDirs/variant/default.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from '../../importConfigFiles.test.js';
+
+export const config: TestConfig = {
+    shallowProperty: 'default',
+    nestedObject: {
+        nestedProperty1: 'default-n1',
+        nestedProperty2: 'default-n2',
+    },
+};

--- a/src/testConfigDirs/variant/local-customerA.ts
+++ b/src/testConfigDirs/variant/local-customerA.ts
@@ -1,0 +1,8 @@
+import type { DeepPartial } from '../../common.ts';
+import type { TestConfig } from '../../importConfigFiles.test.js';
+
+export const config: DeepPartial<TestConfig> = {
+    nestedObject: {
+        nestedProperty2: 'local-customerA-n2',
+    },
+};

--- a/src/testConfigDirs/variant/local-production-customerA.ts
+++ b/src/testConfigDirs/variant/local-production-customerA.ts
@@ -1,0 +1,8 @@
+import type { DeepPartial } from '../../common.ts';
+import type { TestConfig } from '../../importConfigFiles.test.js';
+
+export const config: DeepPartial<TestConfig> = {
+    nestedObject: {
+        nestedProperty1: 'local-production-customerA-n1',
+    },
+};

--- a/src/testConfigDirs/variant/local-production.ts
+++ b/src/testConfigDirs/variant/local-production.ts
@@ -1,0 +1,6 @@
+import type { DeepPartial } from '../../common.ts';
+import type { TestConfig } from '../../importConfigFiles.test.js';
+
+export const config: DeepPartial<TestConfig> = {
+    shallowProperty: 'local-production',
+};

--- a/src/testConfigDirs/variant/local.ts
+++ b/src/testConfigDirs/variant/local.ts
@@ -1,0 +1,8 @@
+import type { DeepPartial } from '../../common.ts';
+import type { TestConfig } from '../../importConfigFiles.test.js';
+
+export const config: DeepPartial<TestConfig> = {
+    nestedObject: {
+        nestedProperty2: 'local-n2',
+    },
+};

--- a/src/testConfigDirs/variant/production-customerA.ts
+++ b/src/testConfigDirs/variant/production-customerA.ts
@@ -1,0 +1,6 @@
+import type { DeepPartial } from '../../common.ts';
+import type { TestConfig } from '../../importConfigFiles.test.js';
+
+export const config: DeepPartial<TestConfig> = {
+    shallowProperty: 'production-customerA',
+};

--- a/src/testConfigDirs/variant/production.ts
+++ b/src/testConfigDirs/variant/production.ts
@@ -1,0 +1,9 @@
+import type { DeepPartial } from '../../common.ts';
+import type { TestConfig } from '../../importConfigFiles.test.js';
+
+export const config: DeepPartial<TestConfig> = {
+    shallowProperty: 'production',
+    nestedObject: {
+        nestedProperty2: 'production-n2',
+    },
+};


### PR DESCRIPTION
# Why

To allow defininig 2nd dimension of configs without duplicating config files


# What

feat: add support for optinal `variant` configuration
