### PR TITLE
feat: allow JSON.stringify on secure config

### DIFF
--- a/src/makeSecureDeepProxy.test.ts
+++ b/src/makeSecureDeepProxy.test.ts
@@ -139,4 +139,15 @@ describe('makeSecureDeepProxy', () => {
             proxy.a[1].b;
         }, /Property b is not defined in the config/);
     });
+
+    it('allows JSON.stringify on secure config', () => {
+        const config = {
+            a: 1,
+            nested: { b: 'text' },
+        };
+
+        const proxy = makeSecureDeepProxy(config);
+
+        assert.equal(JSON.stringify(proxy), '{"a":1,"nested":{"b":"text"}}');
+    });
 });

--- a/src/makeSecureDeepProxy.ts
+++ b/src/makeSecureDeepProxy.ts
@@ -29,8 +29,10 @@ function makeSecureProxy<T extends DefaultConfig>(targetObject: T): T {
             // Handle Symbol and Array properties
             if (
                 typeof prop === 'symbol' ||
-                // Don't throw error when using array methods
-                (Array.isArray(target) && Number.isNaN(Number(prop)))
+                /** Don't throw error when using array methods */
+                (Array.isArray(target) && Number.isNaN(Number(prop))) ||
+                /** Allow stringifying proxied config (because JSON.stringify calls this method) */
+                prop === 'toJSON'
             ) {
                 return Reflect.get(target, prop);
             }


### PR DESCRIPTION
# Why

Because stringifying should be allowed, there is no reason to block it even when config is secured

# What

feat: allow JSON.stringify on secure config
