### PR TITLE
build: add `publish` Github Actions workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,37 @@
+# Publish to NPM and JSR registries whenever a tag is pushed
+name: Release package
+
+on:
+  push:
+    tags: v*
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # The OIDC ID token is used for authentication with NPM and JSR
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".node-version"
+
+      - name: Install dependencies
+        run: npm clean-install
+
+      - name: Test
+        run: node --run ci
+
+      - name: Build
+        run: node --run build
+
+      # Using "NPM trusted publishing" to authenticate
+      - name: Publish package to NPM
+        run: npm publish
+
+      # Using "JSR publshing from Github Actions" to authenticate
+      - name: Publish package to JSR
+        run: npx jsr publish

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,3 +1,5 @@
+name: Run tests and build
+
 on:
   pull_request:
     types: [opened, synchronize]
@@ -7,13 +9,11 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version-file: '.node-version'
-          cache: npm
-          cache-dependency-path: package-lock.json
+          node-version-file: ".node-version"
 
       - name: Install dependencies
         run: npm clean-install

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
 		"type": "git",
 		"url": "git+https://github.com/mdrobny/configate.git"
 	},
+	"publishConfig": {
+		"registry": "https://registry.npmjs.org",
+		"provenance": true
+	},
 	"keywords": [
 		"config"
 	],
@@ -43,5 +47,15 @@
 		"@biomejs/biome": "2.3.8",
 		"@types/node": "^22.10.6",
 		"typescript": "^5.7.3"
+	},
+	"devEngines": {
+		"runtime": {
+			"name": "node",
+			"onFail": "error"
+		},
+		"packageManager": {
+			"name": "npm",
+			"onFail": "error"
+		}
 	}
 }


### PR DESCRIPTION
# What

build: add `publish` Github Actions workflow
- to automate release process of the package to NPM and JSR registries
- to use "trusted publishing" mechanism

ci: update actions version in `run-tests` workflow
